### PR TITLE
Use common page link attribute inline help texts

### DIFF
--- a/app/assets/javascripts/pageflow/internal_links/editor/views/edit_page_link_view.js
+++ b/app/assets/javascripts/pageflow/internal_links/editor/views/edit_page_link_view.js
@@ -17,7 +17,11 @@ pageflow.internalLinks.EditPageLinkView = Backbone.Marionette.Layout.extend({
 
   onRender: function() {
     var configurationEditor = new pageflow.ConfigurationEditorView({
-      model: this.model
+      model: this.model,
+      attributeTranslationKeyPrefixes: [
+        'pageflow.internal_links.page_link_attributes',
+        'pageflow.common_page_link_attributes'
+      ]
     });
 
     this.configure(configurationEditor);

--- a/config/locales/new/inline_help.de.yml
+++ b/config/locales/new/inline_help.de.yml
@@ -1,0 +1,32 @@
+de:
+  activerecord:
+    attributes:
+      pageflow/internal_links/page_link:
+        description: DELETE
+        label: DELTE
+        page_transition: DELETE
+        target_page_id: DELETE
+      pageflow/page:
+        linked_pages_layout: DELETE
+    values:
+      pageflow/page:
+        linked_pages_layout:
+          default: DELETE
+          hero_top_left: DELETE
+          hero_top_right: DELETE
+
+  pageflow:
+    internal_links:
+      page_link_attributes:
+        description:
+          label: Beschreibung
+          inline_help: Dieser Text wird auf dem Verweis angezeigt.
+      grid:
+        page_attributes:
+          linked_pages_layout:
+            label: Hervorgehobenes Element
+            inline_help: Ein Thumbnail im Mosaik kann größer dargestellt werden.
+            values:
+              default: (Kein)
+              hero_top_left: Links oben
+              hero_top_right: Rechts oben

--- a/config/locales/new/inline_help.en.yml
+++ b/config/locales/new/inline_help.en.yml
@@ -1,0 +1,32 @@
+en:
+  activerecord:
+    attributes:
+      pageflow/internal_links/page_link:
+        description: DELETE
+        label: DELTE
+        page_transition: DELETE
+        target_page_id: DELETE
+      pageflow/page:
+        linked_pages_layout: DELETE
+    values:
+      pageflow/page:
+        linked_pages_layout:
+          default: DELETE
+          hero_top_left: DELETE
+          hero_top_right: DELETE
+
+  pageflow:
+    internal_links:
+      page_link_attributes:
+        description:
+          label: Description
+          inline_help: This text is displayed on the link item.
+      grid:
+        page_attributes:
+          linked_pages_layout:
+            label: Enlarged element
+            inline_help: Emphasize one of the thumbnails.
+            values:
+              default: (none)
+              hero_top_left: Top left
+              hero_top_right: Top right

--- a/lib/pageflow/internal_links/engine.rb
+++ b/lib/pageflow/internal_links/engine.rb
@@ -4,6 +4,7 @@ module Pageflow
       isolate_namespace Pageflow::InternalLinks
 
       config.autoload_paths << File.join(config.root, 'lib')
+      config.i18n.load_path += Dir[config.root.join('config', 'locales', '**', '*.yml').to_s]
     end
   end
 end


### PR DESCRIPTION
Use new translation key layout for labels and inline help texts.
