### PR TITLE
Register grid page type in plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Register the page types:
 
     # config/initializers/pageflow.rb
     Pageflow.configure do |config|
-      config.page_types.register(Pageflow::InternalLinks.grid_page_type)
+      config.plugin(Pageflow::InternalLinks.plugin)
     end
 
 Include javascripts and stylesheets:
@@ -51,7 +51,9 @@ Migrate the database:
 
     bundle exec rake db:migrate
 
-Restart the application server.
+Restart the application server. The grid page type is available by
+default. For the list page type enable the corresponding feature in
+the tab *features*.
 
 ## Troubleshooting
 

--- a/lib/pageflow/internal_links/plugin.rb
+++ b/lib/pageflow/internal_links/plugin.rb
@@ -2,6 +2,7 @@ module Pageflow
   module InternalLinks
     class Plugin < Pageflow::Plugin
       def configure(config)
+        config.page_types.register(InternalLinks.grid_page_type)
         config.features.register(PageTypeFeature.new(InternalLinks.list_page_type))
       end
     end


### PR DESCRIPTION
Before only the feature for the list page type was registered inside
plugin. The grid page type had to be registered separately. This
separate register call now needs to be removed if the plugin is used.