### PR TITLE
Rewrite helpers to use image file perma ids

### DIFF
--- a/app/helpers/pageflow/internal_links/grid_helper.rb
+++ b/app/helpers/pageflow/internal_links/grid_helper.rb
@@ -3,7 +3,7 @@ module Pageflow
     module GridHelper
       def internal_links_grid(entry, configuration)
         Grid.new(self,
-                 InternalLinks::PageLinks.deserialize(entry, configuration),
+                 InternalLinks::PageLinks.deserialize(self, entry, configuration),
                  configuration['linked_pages_layout']).render
       end
 

--- a/app/helpers/pageflow/internal_links/list_helper.rb
+++ b/app/helpers/pageflow/internal_links/list_helper.rb
@@ -3,7 +3,7 @@ module Pageflow
     module ListHelper
       def internal_links_list(entry, configuration)
         render('pageflow/internal_links/list/list',
-               page_links: InternalLinks::PageLinks.deserialize(entry, configuration))
+               page_links: InternalLinks::PageLinks.deserialize(self, entry, configuration))
       end
     end
   end

--- a/app/helpers/pageflow/internal_links/page_links.rb
+++ b/app/helpers/pageflow/internal_links/page_links.rb
@@ -1,8 +1,8 @@
 module Pageflow
   module InternalLinks
-    class PageLinks < Struct.new(:entry, :configuration)
-      def self.deserialize(entry, configuration)
-        new(entry, configuration).deserialize
+    class PageLinks < Struct.new(:template, :entry, :configuration)
+      def self.deserialize(template, entry, configuration)
+        new(template, entry, configuration).deserialize
       end
 
       def deserialize
@@ -29,7 +29,8 @@ module Pageflow
 
       def parse_collection(collection)
         collection.map do |attributes|
-          PageLink.new(attributes['target_page_id'],
+          PageLink.new(template,
+                       attributes['target_page_id'],
                        attributes['position'].to_i,
                        attributes['page_transition'],
                        attributes['description'],
@@ -39,12 +40,13 @@ module Pageflow
 
       def parse_legacy_hash(hash)
         hash.map do |position, target_page_id|
-          PageLink.new(target_page_id, (position.to_i - 1), nil, nil, nil)
+          PageLink.new(template, target_page_id, (position.to_i - 1), nil, nil, nil)
         end
       end
     end
 
-    class PageLink < Struct.new(:target_page_id,
+    class PageLink < Struct.new(:template,
+                                :target_page_id,
                                 :position,
                                 :page_transition,
                                 :optional_description,
@@ -62,7 +64,7 @@ module Pageflow
 
       def thumbnail_file
         custom_thumbnail_file ||
-          (target_page && target_page.thumbnail_file)
+          (target_page && template.page_thumbnail_file(target_page))
       end
 
       def css_class
@@ -87,7 +89,8 @@ module Pageflow
       private
 
       def custom_thumbnail_file
-        @custom_thumbnail_file = ImageFile.find_by_id(custom_thumbnail_image_id)
+        @custom_thumbnail_file = template.find_file_in_entry(ImageFile,
+                                                             custom_thumbnail_image_id)
       end
 
       def target_page_description

--- a/pageflow-internal-links.gemspec
+++ b/pageflow-internal-links.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '~> 2.1'
 
-  spec.add_runtime_dependency 'pageflow', ['>= 14', '< 16']
+  spec.add_runtime_dependency 'pageflow', '~> 15.x'
 
   spec.add_development_dependency 'bundler', ['>= 1.0', '< 3']
-  spec.add_development_dependency 'pageflow-support', ['>= 14', '< 16']
+  spec.add_development_dependency 'pageflow-support', '~> 15.x'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec-rails', '~> 3.0'
 

--- a/spec/integration/page_types_spec.rb
+++ b/spec/integration/page_types_spec.rb
@@ -1,5 +1,90 @@
 require 'spec_helper'
 require 'pageflow/lint'
+require 'pageflow/used_file_test_helper'
 
 Pageflow::Lint.page_type(Pageflow::InternalLinks.grid_page_type)
 Pageflow::Lint.page_type(Pageflow::InternalLinks.list_page_type)
+
+module Pageflow
+  module InternalLinks
+    describe 'page type', type: :helper do
+      include RenderPageTestHelper
+      include UsedFileTestHelper
+
+      before do
+        pageflow_configure do |config|
+          config.plugin(InternalLinks.plugin)
+          config.features.enable_by_default('page_type.internal_links_list')
+        end
+
+        helper.extend(Pageflow::FileThumbnailsHelper)
+        helper.extend(Pageflow::PagesHelper)
+      end
+
+      describe 'grid' do
+        it 'renders internal links' do
+          revision = create(:revision)
+          other_page = create(:page, revision: revision)
+          page = create(:page,
+                        template: InternalLinks.grid_page_type.name,
+                        revision: revision,
+                        configuration: {
+                          internal_links: [
+                            {
+                              target_page_id: other_page.perma_id
+                            }
+                          ]
+                        })
+
+          html = render_page(page)
+
+          expect(html).to have_selector("nav a[data-page=#{other_page.perma_id}]")
+        end
+      end
+
+      describe 'list' do
+        it 'renders internal links' do
+          revision = create(:revision)
+          other_page = create(:page, revision: revision)
+          page = create(:page,
+                        template: InternalLinks.list_page_type.name,
+                        revision: revision,
+                        configuration: {
+                          internal_links: [
+                            {
+                              target_page_id: other_page.perma_id
+                            }
+                          ]
+                        })
+
+          html = render_page(page)
+
+          expect(html).to have_selector("nav a[data-page=#{other_page.perma_id}]")
+        end
+
+        it 'looks up custom thumbnail by perma id' do
+          revision = create(:revision)
+          entry = Pageflow::PublishedEntry.new(create(:entry), revision)
+          other_page = create(:page, revision: revision)
+          image_file = create_used_file(:image_file, entry: entry)
+          page = create(:page,
+                        template: InternalLinks.list_page_type.name,
+                        revision: revision,
+                        configuration: {
+                          internal_links: [
+                            {
+                              target_page_id: other_page.perma_id,
+                              thumbnail_image_id: image_file.perma_id
+                            }
+                          ]
+                        })
+
+          html = render_page(page)
+
+          expect(html)
+            .to have_selector("nav a .pageflow_image_file_link_thumbnail_large_#{image_file.perma_id}")
+        end
+      end
+    end
+  end
+end

--- a/spec/support/config/factory_bot.rb
+++ b/spec/support/config/factory_bot.rb
@@ -1,0 +1,6 @@
+require 'factory_bot_rails'
+
+RSpec.configure do |config|
+  # Allow to use build and create methods without FactoryBot prefix.
+  config.include FactoryBot::Syntax::Methods
+end


### PR DESCRIPTION
* Use `page_thumbnail_file` helper instead of trying to read
  `page.thumbnail_file` directly.

* Use `find_file_in_entry` to look up custom link thumbnail.

* Add integration tests which render link lists.

REDMINE-16809