### PR TITLE
fixed internal links bug by giving padding to hero-left.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in chart.gemspec
+gem 'rails', '~> 5.2.0'
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in chart.gemspec
-gem 'rails', '~> 5.2.0'
+gem 'rails', '~> 5.2.0' #Added specific rails version because the travis tests were failing due to dependancy problem. REDMIN#17649
 gemspec

--- a/app/assets/stylesheets/pageflow/internal_links/grid.scss
+++ b/app/assets/stylesheets/pageflow/internal_links/grid.scss
@@ -133,6 +133,7 @@
       @extend %hero;
       float: left;
       margin: 0;
+      padding: 0 0.8% 0 0px;
 
       @include phone {
         float: none;


### PR DESCRIPTION
[REDMINE#17649](https://redmine.codevise.de/issues/17649)

- The top left big image was missing padding necessary for the alignment of images, instead it was receiving the same padding as for the smaller images which was more than to keep all the images aligned in the presence of a bigger image.

- The Top right enlarged image had the padding, but the left one was missing.